### PR TITLE
[feat] 변수명 통일 (wiwName, sdName, localId, metroId, gender)

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,7 @@ from routers import scrapResult, commonInfo
 from contextlib import asynccontextmanager
 from typing import Dict
 from model import MongoDB
-from model.ResponseType import ChartResponse, SexInfo, PartyInfo, AgeInfo
-
+from model.ResponseType import ChartResponse, GenderInfo, PartyInfo, AgeInfo
 
 
 @asynccontextmanager
@@ -15,7 +14,7 @@ async def initMongo(app: FastAPI):
     MongoDB.client.close()
 
 
-new = ChartResponse[SexInfo]
+new = ChartResponse[GenderInfo]
 
 app = FastAPI(lifespan=initMongo, responses={404: {"description": "Not found"}})
 

--- a/model/ResponseType.py
+++ b/model/ResponseType.py
@@ -1,44 +1,32 @@
 from pydantic import BaseModel
 from typing import TypeVar, Generic
 
+
 class LocalInfo(BaseModel):
-    name : str
-    id : int
+    name: str
+    id: int
 
 
 class RegionInfo(BaseModel):
-    name : str
-    id : int
+    name: str
+    id: int
     local: list[LocalInfo]
 
+
 class PartyInfo(BaseModel):
-    name : str
-    color : int
+    name: str
+    color: int
 
-    model_config = {
-        "json_schema_extra": {
-            "example" : {
-                "name": "정상이당",
-                "count": 10
-            }
-        }
-    }
-
+    model_config = {"json_schema_extra": {"example": {"name": "정상이당", "count": 10}}}
 
 
 class Diversity(BaseModel):
-    action_type : str
-    value : float
+    action_type: str
+    value: float
 
     model_config = {
-        "json_schema_extra": {
-            "example" : {
-                "action_type": "sex",
-                "value": 0.5
-            }
-        }
+        "json_schema_extra": {"example": {"action_type": "gender", "value": 0.5}}
     }
-
 
 
 class AgeInfo(BaseModel):
@@ -47,55 +35,30 @@ class AgeInfo(BaseModel):
     count: int
 
     model_config = {
-        "json_schema_extra": {
-            "example" : {
-                "minAge": 10,
-                "maxAge": 20,
-                "count": 10
-            }
-        }
+        "json_schema_extra": {"example": {"minAge": 10, "maxAge": 20, "count": 10}}
     }
+
 
 class PartyInfo(BaseModel):
-    party : str
-    count : int
-
-    model_config = {
-        "json_schema_extra": {
-            "example" : {
-                "party": "숭구리당당",
-                "count": 10
-            }
-        }
-    }
-
-class SexInfo(BaseModel):
-    sex: str
+    party: str
     count: int
 
-    model_config = {
-        "json_schema_extra": {
-            "example" : {
-                "sex": "male",
-                "count": 10
-            }
-        }
-    }
+    model_config = {"json_schema_extra": {"example": {"party": "숭구리당당", "count": 10}}}
 
-T = TypeVar("T", SexInfo, PartyInfo, AgeInfo)
+
+class GenderInfo(BaseModel):
+    gender: str
+    count: int
+
+    model_config = {"json_schema_extra": {"example": {"gender": "male", "count": 10}}}
+
+
+T = TypeVar("T", GenderInfo, PartyInfo, AgeInfo)
+
 
 class ChartResponse(BaseModel, Generic[T]):
-    data : list[T]
+    data: list[T]
 
     model_config = {
-        "json_schema_extra": {
-            "example" : {
-                "data": [
-                    {
-                        "sex": "male",
-                        "count": 10
-                    }
-                ]
-            }
-        }
+        "json_schema_extra": {"example": {"data": [{"gender": "male", "count": 10}]}}
     }

--- a/model/ScrapResult.py
+++ b/model/ScrapResult.py
@@ -3,13 +3,13 @@ from enum import StrEnum
 from typing import TypeVar, Generic
 
 
-class SexType(StrEnum):
+class GenderType(StrEnum):
     male = "남"
     female = "여"
 
 
 class FactorType(StrEnum):
-    sex = "sex"
+    gender = "gender"
     age = "age"
     party = "party"
 
@@ -17,8 +17,8 @@ class FactorType(StrEnum):
 # ==============================================
 # =            Template Data Types             =
 # ==============================================
-class SexTemplateData(BaseModel):
-    sexDiversityIndex: float
+class GenderTemplateData(BaseModel):
+    genderDiversityIndex: float
 
 
 class AgeTemplateData(BaseModel):
@@ -32,11 +32,9 @@ class PartyTemplateData(BaseModel):
 # ==============================================
 # =             Chart Data Types               =
 # ==============================================
-class SexChartDataPoint(BaseModel):
-    sex: SexType
+class GenderChartDataPoint(BaseModel):
+    gender: GenderType
     count: int
-
-
 
 
 class AgeChartDataPoint(BaseModel):
@@ -45,13 +43,13 @@ class AgeChartDataPoint(BaseModel):
     count: int
 
 
-
 class PartyChartDataPoint(BaseModel):
     party: str
     count: int
 
 
-T = TypeVar("T", SexChartDataPoint, AgeChartDataPoint, PartyChartDataPoint)
+T = TypeVar("T", GenderChartDataPoint, AgeChartDataPoint, PartyChartDataPoint)
+
 
 class ChartData(BaseModel, Generic[T]):
     data: list[T]

--- a/routers/commonInfo.py
+++ b/routers/commonInfo.py
@@ -13,13 +13,17 @@ async def getRegionInfo() -> list[CommonInfo.RegionInfo]:
         local_districts = []
         async for local in MongoDB.client.district_db.get_collection(
             "local_district"
-        ).find({"metro_id": metro["metro_id"]}):
-            local_districts.append(CommonInfo.LocalInfo.model_validate({"name": local["name_ko"], "id": local["local_id"]}))
+        ).find({"metroId": metro["metroId"]}):
+            local_districts.append(
+                CommonInfo.LocalInfo.model_validate(
+                    {"name": local["wiwName"], "id": local["localId"]}
+                )
+            )
         regions.append(
             CommonInfo.RegionInfo.model_validate(
                 {
-                    "name": metro["name_ko"],
-                    "id": metro["metro_id"],
+                    "name": metro["sdName"],
+                    "id": metro["metroId"],
                     "local": local_districts,
                 }
             )


### PR DESCRIPTION
상기한 변수명을 통일합니다. DB의 document도 이에 맞게 수정하였습니다.
현재는 chart_data와 template_data에서 정당은 실행되지 않습니다.
API repo에서 기존에 이용하던 Councilor 클래스가 jdName 필드를 저장하지 않았기 때문으로, DB 상의 데이터만 수정되면 정상적으로 실행될 것으로 예상합니다.