### PR TITLE
[feat] 국회의원 정보 반환

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,12 @@
 from fastapi import FastAPI, Request
 from dotenv import load_dotenv
-from routers import commonInfo, ageHist, scrapResultLocal, scrapResultMetro
+from routers import (
+    commonInfo,
+    ageHist,
+    scrapResultLocal,
+    scrapResultMetro,
+    scrapResultNational,
+)
 from contextlib import asynccontextmanager
 from typing import Dict
 from model import MongoDB
@@ -35,5 +41,6 @@ app.add_middleware(
 
 app.include_router(scrapResultLocal.router)
 app.include_router(scrapResultMetro.router)
+app.include_router(scrapResultNational.router)
 app.include_router(commonInfo.router)
 app.include_router(ageHist.router)

--- a/model/AgeHist.py
+++ b/model/AgeHist.py
@@ -19,6 +19,10 @@ class AgeHistDataPoint(BaseModel):
     ageGroup: int
 
 
+class NationalAgeHistData(BaseModel):
+    data: list[AgeHistDataPoint]
+
+
 class MetroAgeHistData(BaseModel):
     metroId: int
     data: list[AgeHistDataPoint]

--- a/model/BasicResponse.py
+++ b/model/BasicResponse.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 SUCCESS = 200
 REGION_CODE_ERR = 400
 COLLECTION_NOT_EXIST_ERR = 600
+NO_DATA_ERROR = 800
 
 
 class MessageResponse(BaseModel):
@@ -15,3 +16,12 @@ class ErrorResponse(BaseModel):
     error: str
     code: int
     message: str
+
+
+NO_DATA_ERROR_RESPONSE: ErrorResponse = ErrorResponse.model_validate(
+    {
+        "error": "NoDataError",
+        "code": NO_DATA_ERROR,
+        "message": "No data was retrieved with the provided input.",
+    }
+)

--- a/model/ScrapResultLocal.py
+++ b/model/ScrapResultLocal.py
@@ -5,7 +5,18 @@ from pydantic import BaseModel
 # =            Template Data Types             =
 # ==============================================
 class GenderTemplateDataLocal(BaseModel):
+    class GenderTemplateDataPoint(BaseModel):
+        year: int
+        malePop: int
+        femalePop: int
+
+    metroId: int
+    localId: int
     genderDiversityIndex: float
+    current: GenderTemplateDataPoint
+    prev: GenderTemplateDataPoint
+    meanMalePop: float
+    meanFemalePop: float
 
 
 class AgeTemplateDataLocal(BaseModel):
@@ -53,4 +64,13 @@ class AgeTemplateDataLocal(BaseModel):
 
 
 class PartyTemplateDataLocal(BaseModel):
+    class PartyCountDataPoint(BaseModel):
+        party: str
+        count: int
+
+    metroId: int
+    localId: int
     partyDiversityIndex: float
+    prevElected: list[PartyCountDataPoint]
+    currentElected: list[PartyCountDataPoint]
+    currentCandidate: list[PartyCountDataPoint]

--- a/model/ScrapResultMetro.py
+++ b/model/ScrapResultMetro.py
@@ -5,7 +5,17 @@ from pydantic import BaseModel
 # =            Template Data Types             =
 # ==============================================
 class GenderTemplateDataMetro(BaseModel):
+    class GenderTemplateDataPoint(BaseModel):
+        year: int
+        malePop: int
+        femalePop: int
+
+    metroId: int
     genderDiversityIndex: float
+    current: GenderTemplateDataPoint
+    prev: GenderTemplateDataPoint
+    meanMalePop: float
+    meanFemalePop: float
 
 
 class AgeTemplateDataMetro(BaseModel):
@@ -52,4 +62,12 @@ class AgeTemplateDataMetro(BaseModel):
 
 
 class PartyTemplateDataMetro(BaseModel):
+    class PartyCountDataPoint(BaseModel):
+        party: str
+        count: int
+
+    metroId: int
     partyDiversityIndex: float
+    prevElected: list[PartyCountDataPoint]
+    currentElected: list[PartyCountDataPoint]
+    currentCandidate: list[PartyCountDataPoint]

--- a/model/ScrapResultNational.py
+++ b/model/ScrapResultNational.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel
+
+
+# ==============================================
+# =            Template Data Types             =
+# ==============================================
+class GenderTemplateDataNational(BaseModel):
+    genderDiversityIndex: float
+
+
+class AgeTemplateDataNational(BaseModel):
+    class AgeRankingParagraphData(BaseModel):
+        ageDiversityIndex: float
+
+    class AgeIndexHistoryParagraphData(BaseModel):
+        class AgeIndexHistoryIndexData(BaseModel):
+            year: int
+            unit: int
+            candidateCount: int
+            candidateDiversityIndex: float
+            candidateDiversityRank: int
+            electedDiversityIndex: float
+            electedDiversityRank: int
+
+        mostRecentYear: int
+        history: list[AgeIndexHistoryIndexData]
+
+    class AgeHistogramParagraphData(BaseModel):
+        year: int
+        candidateCount: int
+        electedCount: int
+        firstQuintile: int
+        lastQuintile: int
+
+    rankingParagraph: AgeRankingParagraphData
+    indexHistoryParagraph: AgeIndexHistoryParagraphData
+    ageHistogramParagraph: AgeHistogramParagraphData
+
+
+class PartyTemplateDataNational(BaseModel):
+    partyDiversityIndex: float

--- a/model/ScrapResultNational.py
+++ b/model/ScrapResultNational.py
@@ -5,7 +5,14 @@ from pydantic import BaseModel
 # =            Template Data Types             =
 # ==============================================
 class GenderTemplateDataNational(BaseModel):
+    class GenderTemplateDataPoint(BaseModel):
+        year: int
+        malePop: int
+        femalePop: int
+
     genderDiversityIndex: float
+    current: GenderTemplateDataPoint
+    prev: GenderTemplateDataPoint
 
 
 class AgeTemplateDataNational(BaseModel):
@@ -38,4 +45,11 @@ class AgeTemplateDataNational(BaseModel):
 
 
 class PartyTemplateDataNational(BaseModel):
+    class PartyCountDataPoint(BaseModel):
+        party: str
+        count: int
+
     partyDiversityIndex: float
+    prevElected: list[PartyCountDataPoint]
+    currentElected: list[PartyCountDataPoint]
+    currentCandidate: list[PartyCountDataPoint]

--- a/routers/ageHist.py
+++ b/routers/ageHist.py
@@ -1,6 +1,11 @@
 from fastapi import APIRouter
 from model import BasicResponse, MongoDB
-from model.AgeHist import AgeHistDataTypes, AgeHistMethodTypes, MetroAgeHistData
+from model.AgeHist import (
+    AgeHistDataTypes,
+    AgeHistMethodTypes,
+    MetroAgeHistData,
+    NationalAgeHistData,
+)
 
 
 router = APIRouter(prefix="/age-hist", tags=["age-hist"])
@@ -9,50 +14,153 @@ router = APIRouter(prefix="/age-hist", tags=["age-hist"])
 @router.get("/")
 async def getNationalAgeHistData(
     ageHistType: AgeHistDataTypes, year: int, method: AgeHistMethodTypes
-) -> BasicResponse.ErrorResponse | MetroAgeHistData:
-    histogram = await MongoDB.client.stats_db["age_hist"].find_one(
+) -> BasicResponse.ErrorResponse | NationalAgeHistData:
+    # histogram = await MongoDB.client.stats_db["age_hist"].find_one(
+    #     {
+    #         "councilorType": "national_councilor",
+    #         "is_elected": ageHistType == AgeHistDataTypes.elected,
+    #         "year": year,
+    #         "method": method,
+    #     }
+    # )
+
+    # if histogram is None:
+    #     return BasicResponse.ErrorResponse.model_validate(
+    #         {
+    #             "error": "NoDataError",
+    #             "code": BasicResponse.NO_DATA_ERROR,
+    #             "message": "No data retrieved with the provided input.",
+    #         }
+    #     )
+
+    # return NationalAgeHistData.model_validate({"data": histogram["data"]})
+    return NationalAgeHistData.model_validate(
         {
-            "councilorType": "national_councilor",
-            "is_elected": ageHistType == AgeHistDataTypes.elected,
-            "year": year,
-            "method": method,
+            "data": [
+                {
+                    "minAge": 21,
+                    "maxAge": 22,
+                    "count": 75,
+                    "ageGroup": 0,
+                },
+                {
+                    "minAge": 22,
+                    "maxAge": 23,
+                    "count": 87,
+                    "ageGroup": 1,
+                },
+                {
+                    "minAge": 29,
+                    "maxAge": 30,
+                    "count": 104,
+                    "ageGroup": 2,
+                },
+                {
+                    "minAge": 45,
+                    "maxAge": 46,
+                    "count": 354,
+                    "ageGroup": 2,
+                },
+                {
+                    "minAge": 46,
+                    "maxAge": 47,
+                    "count": 463,
+                    "ageGroup": 3,
+                },
+                {
+                    "minAge": 63,
+                    "maxAge": 64,
+                    "count": 240,
+                    "ageGroup": 4,
+                },
+            ]
         }
     )
-
-    return MetroAgeHistData.model_validate({"data": histogram["data"]})
 
 
 @router.get("/{metroId}")
 async def getMetroAgeHistData(
     metroId: int, ageHistType: AgeHistDataTypes, year: int, method: AgeHistMethodTypes
 ) -> BasicResponse.ErrorResponse | MetroAgeHistData:
-    if (
-        await MongoDB.client.district_db["metro_district"].find_one(
-            {"metroId": metroId}
-        )
-        is None
-    ):
-        return BasicResponse.ErrorResponse.model_validate(
-            {
-                "error": "RegionCodeError",
-                "code": BasicResponse.REGION_CODE_ERR,
-                "message": f"No metro district with metroId {metroId}.",
-            }
-        )
+    # if (
+    #     await MongoDB.client.district_db["metro_district"].find_one(
+    #         {"metroId": metroId}
+    #     )
+    #     is None
+    # ):
+    #     return BasicResponse.ErrorResponse.model_validate(
+    #         {
+    #             "error": "RegionCodeError",
+    #             "code": BasicResponse.REGION_CODE_ERR,
+    #             "message": f"No metro district with metroId {metroId}.",
+    #         }
+    #     )
 
-    histogram = await MongoDB.client.stats_db["age_hist"].find_one(
-        {
-            "level": 1,
-            "councilorType": "metro_councilor",
-            "is_elected": ageHistType == AgeHistDataTypes.elected,
-            "year": year,
-            "method": method,
-            "metroId": metroId,
-        }
-    )
+    # histogram = await MongoDB.client.stats_db["age_hist"].find_one(
+    #     {
+    #         "level": 1,
+    #         "councilorType": "metro_councilor",
+    #         "is_elected": ageHistType == AgeHistDataTypes.elected,
+    #         "year": year,
+    #         "method": method,
+    #         "metroId": metroId,
+    #     }
+    # )
 
+    # if histogram is None:
+    #     return BasicResponse.ErrorResponse.model_validate(
+    #         {
+    #             "error": "NoDataError",
+    #             "code": BasicResponse.NO_DATA_ERROR,
+    #             "message": "No data retrieved with the provided input.",
+    #         }
+    #     )
+
+    # return MetroAgeHistData.model_validate(
+    #     {"metroId": metroId, "data": histogram["data"]}
+    # )
     return MetroAgeHistData.model_validate(
-        {"metroId": metroId, "data": histogram["data"]}
+        {
+            "metroId": metroId,
+            "data": [
+                {
+                    "minAge": 21,
+                    "maxAge": 22,
+                    "count": 75,
+                    "ageGroup": 0,
+                },
+                {
+                    "minAge": 22,
+                    "maxAge": 23,
+                    "count": 87,
+                    "ageGroup": 1,
+                },
+                {
+                    "minAge": 29,
+                    "maxAge": 30,
+                    "count": 104,
+                    "ageGroup": 2,
+                },
+                {
+                    "minAge": 45,
+                    "maxAge": 46,
+                    "count": 354,
+                    "ageGroup": 2,
+                },
+                {
+                    "minAge": 46,
+                    "maxAge": 47,
+                    "count": 463,
+                    "ageGroup": 3,
+                },
+                {
+                    "minAge": 63,
+                    "maxAge": 64,
+                    "count": 240,
+                    "ageGroup": 4,
+                },
+            ],
+        }
     )
 
 
@@ -89,6 +197,15 @@ async def getLocalAgeHistData(
             "localId": localId,
         }
     )
+
+    if histogram is None:
+        return BasicResponse.ErrorResponse.model_validate(
+            {
+                "error": "NoDataError",
+                "code": BasicResponse.NO_DATA_ERROR,
+                "message": "No data retrieved with the provided input.",
+            }
+        )
 
     return MetroAgeHistData.model_validate(
         {"metroId": metroId, "localId": localId, "data": histogram["data"]}

--- a/routers/scrapResultMetro.py
+++ b/routers/scrapResultMetro.py
@@ -67,7 +67,12 @@ async def getMetroTemplateData(
             #    indexHistoryParagraph
             # ============================
             years = list(
-                {doc["year"] async for doc in client.stats_db["age_hist"].find()}
+                {
+                    doc["year"]
+                    async for doc in client.stats_db["age_hist"].find(
+                        {"councilorType": "metro_councilor"}
+                    )
+                }
             )
             years.sort()
             history_candidate = [

--- a/routers/scrapResultMetro.py
+++ b/routers/scrapResultMetro.py
@@ -42,8 +42,30 @@ async def getMetroTemplateData(
 
     match factor:
         case FactorType.gender:
+            councilors = (
+                await client.council_db["metro_councilor"]
+                .find({"metroId": metroId})
+                .to_list(500)
+            )
+            gender_list = [councilor["gender"] for councilor in councilors]
+            gender_count = diversity.count(gender_list)
             return GenderTemplateDataMetro.model_validate(
-                {"genderDiversityIndex": metro_stat["genderDiversityIndex"]}
+                {
+                    "metroId": metroId,
+                    "genderDiversityIndex": metro_stat["genderDiversityIndex"],
+                    "current": {
+                        "year": 2022,
+                        "malePop": gender_count["남"],
+                        "femalePop": gender_count["여"],
+                    },
+                    "prev": {
+                        "year": 0,
+                        "malePop": 0,
+                        "femalePop": 0,
+                    },
+                    "meanMalePop": 0.0,
+                    "meanFemalePop": 0.0,
+                }
             )
 
         case FactorType.age:
@@ -105,65 +127,65 @@ async def getMetroTemplateData(
             # ============================
             #    ageHistogramParagraph
             # ============================
-            age_stat_elected = (
-                await client.stats_db["age_stat"]
-                .aggregate(
-                    [
-                        {
-                            "$match": {
-                                "level": 1,
-                                "councilorType": "metro_councilor",
-                                "is_elected": True,
-                                "metroId": metroId,
-                            }
-                        },
-                        {"$sort": {"year": -1}},
-                        {"$limit": 1},
-                    ]
-                )
-                .to_list(500)
-            )[0]
-            most_recent_year = age_stat_elected["year"]
-            age_stat_candidate = await client.stats_db["age_stat"].find_one(
-                {
-                    "level": 1,
-                    "councilorType": "metro_councilor",
-                    "is_elected": False,
-                    "metroId": metroId,
-                    "year": most_recent_year,
-                }
-            )
+            # age_stat_elected = (
+            #     await client.stats_db["age_hist"]
+            #     .aggregate(
+            #         [
+            #             {
+            #                 "$match": {
+            #                     "level": 1,
+            #                     "councilorType": "metro_councilor",
+            #                     "is_elected": True,
+            #                     "metroId": metroId,
+            #                 }
+            #             },
+            #             {"$sort": {"year": -1}},
+            #             {"$limit": 1},
+            #         ]
+            #     )
+            #     .to_list(500)
+            # )[0]
+            # most_recent_year = age_stat_elected["year"]
+            # age_stat_candidate = await client.stats_db["age_hist"].find_one(
+            #     {
+            #         "level": 1,
+            #         "councilorType": "metro_councilor",
+            #         "is_elected": False,
+            #         "metroId": metroId,
+            #         "year": most_recent_year,
+            #     }
+            # )
 
-            divArea_id = (
-                await client.stats_db["diversity_index"].find_one(
-                    {"metroId": {"$exists": True}, "ageDiversityRank": 1}
-                )
-            )["metroId"]
-            divArea = await client.stats_db["age_stat"].find_one(
-                {
-                    "level": 1,
-                    "councilorType": "metro_councilor",
-                    "is_elected": True,
-                    "metroId": divArea_id,
-                    "year": most_recent_year,
-                }
-            )
+            # divArea_id = (
+            #     await client.stats_db["diversity_index"].find_one(
+            #         {"metroId": {"$exists": True}, "ageDiversityRank": 1}
+            #     )
+            # )["metroId"]
+            # divArea = await client.stats_db["age_hist"].find_one(
+            #     {
+            #         "level": 1,
+            #         "councilorType": "metro_councilor",
+            #         "is_elected": True,
+            #         "metroId": divArea_id,
+            #         "year": most_recent_year,
+            #     }
+            # )
 
-            uniArea_id = (
-                await client.stats_db["diversity_index"].find_one(
-                    # {"metroId": {"$exists": True}, "ageDiversityRank": 17}
-                    {"metroId": {"$exists": True}, "ageDiversityRank": 15}
-                )
-            )["metroId"]
-            uniArea = await client.stats_db["age_stat"].find_one(
-                {
-                    "level": 1,
-                    "councilorType": "metro_councilor",
-                    "is_elected": True,
-                    "metroId": uniArea_id,
-                    "year": most_recent_year,
-                }
-            )
+            # uniArea_id = (
+            #     await client.stats_db["diversity_index"].find_one(
+            #         # {"metroId": {"$exists": True}, "ageDiversityRank": 17}
+            #         {"metroId": {"$exists": True}, "ageDiversityRank": 15}
+            #     )
+            # )["metroId"]
+            # uniArea = await client.stats_db["age_hist"].find_one(
+            #     {
+            #         "level": 1,
+            #         "councilorType": "metro_councilor",
+            #         "is_elected": True,
+            #         "metroId": uniArea_id,
+            #         "year": most_recent_year,
+            #     }
+            # )
 
             return AgeTemplateDataMetro.model_validate(
                 {
@@ -195,31 +217,48 @@ async def getMetroTemplateData(
                                 "candidateDiversityRank": history_candidate[idx][
                                     "diversityRank"
                                 ],
-                                "electedDiversityIndex": history_elected[idx][
-                                    "diversityIndex"
-                                ],
-                                "electedDiversityRank": history_elected[idx][
-                                    "diversityRank"
-                                ],
+                                # "electedDiversityIndex": history_elected[idx][
+                                #     "diversityIndex"
+                                # ],
+                                # "electedDiversityRank": history_elected[idx][
+                                #     "diversityRank"
+                                # ],
+                                "electedDiversityIndex": 0.003141592,
+                                "electedDiversityRank": 99999,
                             }
                             for idx, year in enumerate(years)
                         ],
                     },
                     "ageHistogramParagraph": {
-                        "year": most_recent_year,
-                        "candidateCount": age_stat_candidate["data"][0]["population"],
-                        "electedCount": age_stat_elected["data"][0]["population"],
-                        "firstQuintile": age_stat_elected["data"][0]["firstquintile"],
-                        "lastQuintile": age_stat_elected["data"][0]["lastquintile"],
+                        # "year": most_recent_year,
+                        # "candidateCount": age_stat_candidate["data"][0]["population"],
+                        # "electedCount": age_stat_elected["data"][0]["population"],
+                        # "firstQuintile": age_stat_elected["data"][0]["firstquintile"],
+                        # "lastQuintile": age_stat_elected["data"][0]["lastquintile"],
+                        # "divArea": {
+                        #     "metroId": divArea_id,
+                        #     "firstQuintile": divArea["data"][0]["firstquintile"],
+                        #     "lastQuintile": divArea["data"][0]["lastquintile"],
+                        # },
+                        # "uniArea": {
+                        #     "metroId": uniArea_id,
+                        #     "firstQuintile": uniArea["data"][0]["firstquintile"],
+                        #     "lastQuintile": uniArea["data"][0]["lastquintile"],
+                        # },
+                        "year": 2022,
+                        "candidateCount": 99999,
+                        "electedCount": 88888,
+                        "firstQuintile": 74,
+                        "lastQuintile": 21,
                         "divArea": {
-                            "metroId": divArea_id,
-                            "firstQuintile": divArea["data"][0]["firstquintile"],
-                            "lastQuintile": divArea["data"][0]["lastquintile"],
+                            "metroId": 1,
+                            "firstQuintile": 45,
+                            "lastQuintile": 20,
                         },
                         "uniArea": {
-                            "metroId": uniArea_id,
-                            "firstQuintile": uniArea["data"][0]["firstquintile"],
-                            "lastQuintile": uniArea["data"][0]["lastquintile"],
+                            "metroId": 8,
+                            "firstQuintile": 86,
+                            "lastQuintile": 43,
                         },
                     },
                 }
@@ -227,8 +266,39 @@ async def getMetroTemplateData(
 
         case FactorType.party:
             party_diversity_index = metro_stat["partyDiversityIndex"]
+            councilors = (
+                await client.council_db["metro_councilor"]
+                .find({"metroId": metroId})
+                .to_list(500)
+            )
+            party_list = [councilor["jdName"] for councilor in councilors]
+            party_count = diversity.count(party_list)
+
+            candidates = (
+                await client.council_db["metro_councilor_candidate"]
+                .find({"metroId": metroId})
+                .to_list(500)
+            )
+            candidate_party_list = [candidate["jdName"] for candidate in candidates]
+            candidate_party_count = diversity.count(candidate_party_list)
             return PartyTemplateDataMetro.model_validate(
-                {"partyDiversityIndex": party_diversity_index}
+                {
+                    "metroId": metroId,
+                    "partyDiversityIndex": party_diversity_index,
+                    "prevElected": [
+                        {"party": "포도당", "count": 6},
+                        {"party": "유당", "count": 6},
+                        {"party": "과당", "count": 5},
+                    ],
+                    "currentElected": [
+                        {"party": party, "count": party_count[party]}
+                        for party in party_count
+                    ],
+                    "currentCandidate": [
+                        {"party": party, "count": candidate_party_count[party]}
+                        for party in candidate_party_count
+                    ],
+                }
             )
 
 

--- a/routers/scrapResultMetro.py
+++ b/routers/scrapResultMetro.py
@@ -42,29 +42,87 @@ async def getMetroTemplateData(
 
     match factor:
         case FactorType.gender:
-            councilors = (
-                await client.council_db["metro_councilor"]
-                .find({"metroId": metroId})
+            years = list(
+                {
+                    doc["year"]
+                    async for doc in client.stats_db["gender_hist"].find(
+                        {
+                            "councilorType": "metro_councilor",
+                            "level": 1,
+                            "is_elected": True,
+                            "metroId": metroId,
+                        }
+                    )
+                }
+            )
+            years.sort()
+            assert len(years) >= 2
+
+            current = await client.stats_db["gender_hist"].find_one(
+                {
+                    "councilorType": "metro_councilor",
+                    "level": 1,
+                    "is_elected": True,
+                    "metroId": metroId,
+                    "year": years[-1],
+                }
+            )
+
+            previous = await client.stats_db["gender_hist"].find_one(
+                {
+                    "councilorType": "metro_councilor",
+                    "level": 1,
+                    "is_elected": True,
+                    "metroId": metroId,
+                    "year": years[-2],
+                }
+            )
+
+            current_all = (
+                await client.stats_db["gender_hist"]
+                .aggregate(
+                    [
+                        {
+                            "$match": {
+                                "councilorType": "metro_councilor",
+                                "level": 1,
+                                "is_elected": True,
+                                "year": years[-1],
+                            }
+                        },
+                        {
+                            "$group": {
+                                "_id": None,
+                                "male_tot": {"$sum": "$남"},
+                                "female_tot": {"$sum": "$여"},
+                                "district_cnt": {"$sum": 1},
+                            }
+                        },
+                    ]
+                )
                 .to_list(500)
             )
-            gender_list = [councilor["gender"] for councilor in councilors]
-            gender_count = diversity.count(gender_list)
+            assert len(current_all) == 1
+            current_all = current_all[0]
+
             return GenderTemplateDataMetro.model_validate(
                 {
                     "metroId": metroId,
                     "genderDiversityIndex": metro_stat["genderDiversityIndex"],
                     "current": {
-                        "year": 2022,
-                        "malePop": gender_count["남"],
-                        "femalePop": gender_count["여"],
+                        "year": years[-1],
+                        "malePop": current["남"],
+                        "femalePop": current["여"],
                     },
                     "prev": {
-                        "year": 0,
-                        "malePop": 0,
-                        "femalePop": 0,
+                        "year": years[-2],
+                        "malePop": previous["남"],
+                        "femalePop": previous["여"],
                     },
-                    "meanMalePop": 0.0,
-                    "meanFemalePop": 0.0,
+                    "meanMalePop": current_all["male_tot"]
+                    / current_all["district_cnt"],
+                    "meanFemalePop": current_all["female_tot"]
+                    / current_all["district_cnt"],
                 }
             )
 
@@ -266,37 +324,92 @@ async def getMetroTemplateData(
 
         case FactorType.party:
             party_diversity_index = metro_stat["partyDiversityIndex"]
-            councilors = (
-                await client.council_db["metro_councilor"]
-                .find({"metroId": metroId})
-                .to_list(500)
+            years = list(
+                {
+                    doc["year"]
+                    async for doc in client.stats_db["party_hist"].find(
+                        {
+                            "councilorType": "metro_councilor",
+                            "level": 1,
+                            "is_elected": True,
+                            "metroId": metroId,
+                        }
+                    )
+                }
             )
-            party_list = [councilor["jdName"] for councilor in councilors]
-            party_count = diversity.count(party_list)
+            years.sort()
+            assert len(years) >= 2
 
-            candidates = (
-                await client.council_db["metro_councilor_candidate"]
-                .find({"metroId": metroId})
-                .to_list(500)
+            current_elected = client.stats_db["party_hist"].find(
+                {
+                    "councilorType": "metro_councilor",
+                    "level": 1,
+                    "is_elected": True,
+                    "metroId": metroId,
+                    "year": years[-1],
+                },
+                {
+                    "_id": 0,
+                    "councilorType": 0,
+                    "level": 0,
+                    "is_elected": 0,
+                    "metroId": 0,
+                    "year": 0,
+                },
             )
-            candidate_party_list = [candidate["jdName"] for candidate in candidates]
-            candidate_party_count = diversity.count(candidate_party_list)
+            current_candidate = client.stats_db["party_hist"].find(
+                {
+                    "councilorType": "metro_councilor",
+                    "level": 1,
+                    "is_elected": False,
+                    "metroId": metroId,
+                    "year": years[-1],
+                },
+                {
+                    "_id": 0,
+                    "councilorType": 0,
+                    "level": 0,
+                    "is_elected": 0,
+                    "metroId": 0,
+                    "year": 0,
+                },
+            )
+            previous = client.stats_db["party_hist"].find(
+                {
+                    "councilorType": "metro_councilor",
+                    "level": 1,
+                    "is_elected": True,
+                    "metroId": metroId,
+                    "year": years[-2],
+                },
+                {
+                    "_id": 0,
+                    "councilorType": 0,
+                    "level": 0,
+                    "is_elected": 0,
+                    "metroId": 0,
+                    "year": 0,
+                },
+            )
+
             return PartyTemplateDataMetro.model_validate(
                 {
                     "metroId": metroId,
                     "partyDiversityIndex": party_diversity_index,
                     "prevElected": [
-                        {"party": "포도당", "count": 6},
-                        {"party": "유당", "count": 6},
-                        {"party": "과당", "count": 5},
+                        {"party": party, "count": doc[party]}
+                        async for doc in previous
+                        for party in doc
                     ],
                     "currentElected": [
-                        {"party": party, "count": party_count[party]}
-                        for party in party_count
+                        {"party": party, "count": doc[party]}
+                        async for doc in current_elected
+                        for party in doc
                     ],
                     "currentCandidate": [
-                        {"party": party, "count": candidate_party_count[party]}
-                        for party in candidate_party_count
+                        {"party": party, "count": doc[party]}
+                        async for doc in current_candidate
+                        for party in doc
                     ],
                 }
             )
@@ -311,9 +424,11 @@ T = TypeVar(
 
 
 @router.get("/chart-data/{metroId}")
-async def getLocalChartData(
+async def getMetroChartData(
     metroId: int, factor: FactorType
-) -> ErrorResponse | ChartData[T]:
+) -> ErrorResponse | ChartData[GenderChartDataPoint] | ChartData[
+    AgeChartDataPoint
+] | ChartData[PartyChartDataPoint]:
     if (
         await client.district_db["metro_district"].find_one({"metroId": metroId})
         is None
@@ -326,45 +441,110 @@ async def getLocalChartData(
             }
         )
 
-    councilors = client.council_db["metro_councilor"].find({"metroId": metroId})
-
     match factor:
         case FactorType.gender:
-            gender_list = [councilor["gender"] async for councilor in councilors]
-            gender_count = diversity.count(gender_list)
+            gender_cnt = (
+                await client.stats_db["gender_hist"]
+                .find(
+                    {
+                        "councilorType": "metro_councilor",
+                        "level": 1,
+                        "is_elected": True,
+                        "metroId": metroId,
+                    }
+                )
+                .sort({"year": -1})
+                .limit(1)
+                .to_list(5)
+            )[0]
+
             return ChartData[GenderChartDataPoint].model_validate(
                 {
                     "data": [
-                        {"gender": gender, "count": gender_count[gender]}
-                        for gender in gender_count
+                        {"gender": "남", "count": gender_cnt["남"]},
+                        {"gender": "여", "count": gender_cnt["여"]},
                     ]
                 }
             )
 
         case FactorType.age:
-            age_list = [councilor["age"] async for councilor in councilors]
-            age_count = diversity.count(age_list, stair=AGE_STAIR)
+            # age_cnt = (
+            #     await client.stats_db["age_hist"]
+            #     .find(
+            #         {
+            #             "councilorType": "metro_councilor",
+            #             "level": 1,
+            #             "is_elected": True,
+            #             "method": "equal",
+            #             "metroId": metroId,
+            #         }
+            #     )
+            #     .sort({"year": -1})
+            #     .limit(1)
+            #     .to_list(5)
+            # )[0]
+            # age_list = [
+            #     age["minAge"] for age in age_cnt["data"] for _ in range(age["count"])
+            # ]
+            # age_stair = diversity.count(age_list, stair=AGE_STAIR)
+            # return ChartData[AgeChartDataPoint].model_validate(
+            #     {
+            #         "data": [
+            #             {
+            #                 "minAge": age,
+            #                 "maxAge": age + AGE_STAIR,
+            #                 "count": age_stair[age],
+            #             }
+            #             for age in age_stair
+            #         ]
+            #     }
+            # )
             return ChartData[AgeChartDataPoint].model_validate(
                 {
                     "data": [
                         {
-                            "minAge": age,
-                            "maxAge": age + AGE_STAIR,
-                            "count": age_count[age],
-                        }
-                        for age in age_count
+                            "minAge": 20,
+                            "maxAge": 30,
+                            "count": 888,
+                        },
+                        {
+                            "minAge": 50,
+                            "maxAge": 60,
+                            "count": 999,
+                        },
                     ]
                 }
             )
 
         case FactorType.party:
-            party_list = [councilor["jdName"] async for councilor in councilors]
-            party_count = diversity.count(party_list)
+            party_count = (
+                await client.stats_db["party_hist"]
+                .find(
+                    {
+                        "councilorType": "metro_councilor",
+                        "level": 1,
+                        "is_elected": True,
+                        "metroId": metroId,
+                    }
+                )
+                .sort({"year": -1})
+                .limit(1)
+                .to_list(5)
+            )[0]
             return ChartData[PartyChartDataPoint].model_validate(
                 {
                     "data": [
                         {"party": party, "count": party_count[party]}
                         for party in party_count
+                        if party
+                        not in [
+                            "_id",
+                            "councilorType",
+                            "level",
+                            "is_elected",
+                            "metroId",
+                            "year",
+                        ]
                     ]
                 }
             )


### PR DESCRIPTION
국회의원에 대한 다양성 정보 및 연령 히스토그램을 반환하는 endpoint를 구현합니다.
~~아직 정보가 모이지 않아 테스트하지는 못했습니다.~~
현재 모인 정보로 최대한 테스트하여, 수집하지 못하는 정보는 일단 mock data로 대체하여 반환합니다.

Mock data를 반환하는 경우:
- 기초의회
  - ~~이전 선거 성비~~
  - ~~이전 선거 정당 조성비~~
- 광역의회
  - ~~이전 선거 성비~~
  - 당선인 age_hist
  - ageHistogramParagraph 데이터
  - ~~이전 선거 정당 조성비~~
- 국회
  - ~~이전 선거 성비~~
  - ageHistogramParagraph 데이터
  - ~~이전 선거 정당 조성비~~
  - ~~이번 선거 후보자 정당 조성비~~
- 광역의회, 국회 연령 히스토그램 데이터